### PR TITLE
Conditional edge & Any type state

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/langgraphgo.iml
+++ b/.idea/langgraphgo.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/langgraphgo.iml" filepath="$PROJECT_DIR$/.idea/langgraphgo.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -7,41 +7,6 @@ import (
 	g "github.com/tmc/langgraphgo/graph"
 )
 
-// TestMessageGraph_Compile tests compiling a simple graph.
-func TestMessageGraph_AddNode(t *testing.T) {
-	graph := g.NewMessageGraph()
-	graph.AddNode("node1", func(_ context.Context, state interface{}) (interface{}, error) {
-		return state, nil
-	})
-	if _, exists := graph.nodes["node1"]; !exists {
-		t.Errorf("Expected node 'node1' to be in graph nodes")
-	}
-}
-
-// TestMessageGraph_AddEdge tests adding an edge to the graph.
-func TestMessageGraph_AddEdge(t *testing.T) {
-	graph := g.NewMessageGraph()
-	graph.AddNode("node1", func(_ context.Context, state interface{}) (interface{}, error) {
-		return state, nil
-	})
-	graph.AddNode("node2", func(_ context.Context, state interface{}) (interface{}, error) {
-		return state, nil
-	})
-	graph.AddNode(g.END, func(_ context.Context, state interface{}) (interface{}, error) {
-		return state, nil
-	})
-
-	graph.AddEdge("node1", "node2")
-	graph.AddEdge("node2", g.END)
-
-	if len(graph.edges) != 2 {
-		t.Errorf("Expected 2 edges, got %d", len(graph.edges))
-	}
-	if graph.edges[0].From != "node1" || graph.edges[0].To != "node2" {
-		t.Errorf("Expected edge from 'node1' to 'node2', got from '%s' to '%s'", graph.edges[0].From, graph.edges[0].To)
-	}
-}
-
 // TestMessageGraph_AddConditionalEdge tests adding a conditional edge to the graph.
 func TestMessageGraph_Compile(t *testing.T) {
 	graph := g.NewMessageGraph()
@@ -121,7 +86,7 @@ func TestRunnable_InvokeWithConditionalEdge(t *testing.T) {
 		agentState.visited = "node3"
 		return agentState, nil
 	})
-	graph.AddNode(END, func(_ context.Context, state interface{}) (interface{}, error) {
+	graph.AddNode(g.END, func(_ context.Context, state interface{}) (interface{}, error) {
 		return state, nil
 	})
 	graph.AddConditionalEdge("node1", "node2", "node3", func(_ context.Context, state interface{}) (bool, error) {

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -2,178 +2,151 @@ package graph_test
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"testing"
 
-	"github.com/tmc/langchaingo/llms"
-	"github.com/tmc/langchaingo/llms/openai"
-	"github.com/tmc/langchaingo/schema"
-	"github.com/tmc/langgraphgo/graph"
+	g "github.com/tmc/langgraphgo/graph"
 )
 
-func ExampleMessageGraph() {
-	model, err := openai.New()
-	if err != nil {
-		panic(err)
-	}
-
-	g := graph.NewMessageGraph()
-
-	g.AddNode("oracle", func(ctx context.Context, state []llms.MessageContent) ([]llms.MessageContent, error) {
-		r, err := model.GenerateContent(ctx, state, llms.WithTemperature(0.0))
-		if err != nil {
-			return nil, err
-		}
-		return append(state,
-			llms.TextParts(schema.ChatMessageTypeAI, r.Choices[0].Content),
-		), nil
+// TestMessageGraph_Compile tests compiling a simple graph.
+func TestMessageGraph_AddNode(t *testing.T) {
+	graph := g.NewMessageGraph()
+	graph.AddNode("node1", func(_ context.Context, state interface{}) (interface{}, error) {
+		return state, nil
 	})
-	g.AddNode(graph.END, func(_ context.Context, state []llms.MessageContent) ([]llms.MessageContent, error) {
+	if _, exists := graph.nodes["node1"]; !exists {
+		t.Errorf("Expected node 'node1' to be in graph nodes")
+	}
+}
+
+// TestMessageGraph_AddEdge tests adding an edge to the graph.
+func TestMessageGraph_AddEdge(t *testing.T) {
+	graph := g.NewMessageGraph()
+	graph.AddNode("node1", func(_ context.Context, state interface{}) (interface{}, error) {
+		return state, nil
+	})
+	graph.AddNode("node2", func(_ context.Context, state interface{}) (interface{}, error) {
+		return state, nil
+	})
+	graph.AddNode(g.END, func(_ context.Context, state interface{}) (interface{}, error) {
 		return state, nil
 	})
 
-	g.AddEdge("oracle", graph.END)
-	g.SetEntryPoint("oracle")
+	graph.AddEdge("node1", "node2")
+	graph.AddEdge("node2", g.END)
 
-	runnable, err := g.Compile()
-	if err != nil {
-		panic(err)
+	if len(graph.edges) != 2 {
+		t.Errorf("Expected 2 edges, got %d", len(graph.edges))
 	}
-
-	ctx := context.Background()
-	// Let's run it!
-	res, err := runnable.Invoke(ctx, []llms.MessageContent{
-		llms.TextParts(schema.ChatMessageTypeHuman, "What is 1 + 1?"),
-	})
-	if err != nil {
-		panic(err)
+	if graph.edges[0].From != "node1" || graph.edges[0].To != "node2" {
+		t.Errorf("Expected edge from 'node1' to 'node2', got from '%s' to '%s'", graph.edges[0].From, graph.edges[0].To)
 	}
-
-	fmt.Println(res)
-
-	// Output:
-	// [{human [{What is 1 + 1?}]} {ai [{1 + 1 equals 2.}]}]
 }
 
-func TestMessageGraph(t *testing.T) {
-	t.Parallel()
-	testCases := []struct {
-		name           string
-		buildGraph     func() *graph.MessageGraph
-		inputMessages  []llms.MessageContent
-		expectedOutput []llms.MessageContent
-		expectedError  error
-	}{
-		{
-			name: "Simple graph",
-			buildGraph: func() *graph.MessageGraph {
-				g := graph.NewMessageGraph()
-				g.AddNode("node1", func(_ context.Context, state []llms.MessageContent) ([]llms.MessageContent, error) {
-					return append(state, llms.TextParts(schema.ChatMessageTypeAI, "Node 1")), nil
-				})
-				g.AddNode("node2", func(_ context.Context, state []llms.MessageContent) ([]llms.MessageContent, error) {
-					return append(state, llms.TextParts(schema.ChatMessageTypeAI, "Node 2")), nil
-				})
-				g.AddEdge("node1", "node2")
-				g.AddEdge("node2", graph.END)
-				g.SetEntryPoint("node1")
-				return g
-			},
-			inputMessages: []llms.MessageContent{llms.TextParts(schema.ChatMessageTypeHuman, "Input")},
-			expectedOutput: []llms.MessageContent{
-				llms.TextParts(schema.ChatMessageTypeHuman, "Input"),
-				llms.TextParts(schema.ChatMessageTypeAI, "Node 1"),
-				llms.TextParts(schema.ChatMessageTypeAI, "Node 2"),
-			},
-			expectedError: nil,
-		},
-		{
-			name: "Entry point not set",
-			buildGraph: func() *graph.MessageGraph {
-				g := graph.NewMessageGraph()
-				g.AddNode("node1", func(_ context.Context, state []llms.MessageContent) ([]llms.MessageContent, error) {
-					return state, nil
-				})
-				return g
-			},
-			expectedError: graph.ErrEntryPointNotSet,
-		},
-		{
-			name: "Node not found",
-			buildGraph: func() *graph.MessageGraph {
-				g := graph.NewMessageGraph()
-				g.AddNode("node1", func(_ context.Context, state []llms.MessageContent) ([]llms.MessageContent, error) {
-					return state, nil
-				})
-				g.AddEdge("node1", "node2")
-				g.SetEntryPoint("node1")
-				return g
-			},
-			expectedError: fmt.Errorf("%w: node2", graph.ErrNodeNotFound),
-		},
-		{
-			name: "No outgoing edge",
-			buildGraph: func() *graph.MessageGraph {
-				g := graph.NewMessageGraph()
-				g.AddNode("node1", func(_ context.Context, state []llms.MessageContent) ([]llms.MessageContent, error) {
-					return state, nil
-				})
-				g.SetEntryPoint("node1")
-				return g
-			},
-			expectedError: fmt.Errorf("%w: node1", graph.ErrNoOutgoingEdge),
-		},
-		{
-			name: "Error in node function",
-			buildGraph: func() *graph.MessageGraph {
-				g := graph.NewMessageGraph()
-				g.AddNode("node1", func(_ context.Context, _ []llms.MessageContent) ([]llms.MessageContent, error) {
-					return nil, errors.New("node error")
-				})
-				g.AddEdge("node1", graph.END)
-				g.SetEntryPoint("node1")
-				return g
-			},
-			expectedError: errors.New("error in node node1: node error"),
-		},
+// TestMessageGraph_AddConditionalEdge tests adding a conditional edge to the graph.
+func TestMessageGraph_Compile(t *testing.T) {
+	graph := g.NewMessageGraph()
+	graph.AddNode("node1", func(_ context.Context, state interface{}) (interface{}, error) {
+		return state, nil
+	})
+	graph.AddNode(g.END, func(_ context.Context, state interface{}) (interface{}, error) {
+		return state, nil
+	})
+
+	graph.AddEdge("node1", g.END)
+	graph.SetEntryPoint("node1")
+
+	runnable, err := graph.Compile()
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if runnable == nil {
+		t.Errorf("Expected non-nil runnable")
+	}
+}
+
+// TestRunnable_Invoke tests invoking a simple graph.
+func TestRunnable_Invoke(t *testing.T) {
+	type State struct {
+		visited bool
+	}
+	graph := g.NewMessageGraph()
+	graph.AddNode("node1", func(_ context.Context, state interface{}) (interface{}, error) {
+		agentState, _ := state.(State)
+		agentState.visited = true
+		return agentState, nil
+	})
+	graph.SetEntryPoint("node1")
+	graph.AddNode(g.END, func(_ context.Context, state interface{}) (interface{}, error) {
+		return state, nil
+	})
+
+	graph.AddEdge("node1", g.END)
+
+	runnable, err := graph.Compile()
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			g := tc.buildGraph()
-			runnable, err := g.Compile()
-			if err != nil {
-				if tc.expectedError == nil || !errors.Is(err, tc.expectedError) {
-					t.Fatalf("unexpected compile error: %v", err)
-				}
-				return
-			}
+	state := State{visited: false}
+	result, err := runnable.Invoke(context.Background(), state)
+	stateResult, ok := result.(State)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if !ok || !stateResult.visited {
+		t.Errorf("Expected 'visited' to be true")
+	}
+}
 
-			output, err := runnable.Invoke(context.Background(), tc.inputMessages)
-			if err != nil {
-				if tc.expectedError == nil || err.Error() != tc.expectedError.Error() {
-					t.Fatalf("unexpected invoke error: '%v', expected '%v'", err, tc.expectedError)
-				}
-				return
-			}
+// TestRunnable_InvokeWithConditionalEdge tests invoking a graph with a conditional edge.
+func TestRunnable_InvokeWithConditionalEdge(t *testing.T) {
+	type State struct {
+		condition bool
+		visited   string
+	}
+	graph := g.NewMessageGraph()
+	state := State{}
+	graph.AddNode("node1", func(_ context.Context, state interface{}) (interface{}, error) {
+		agentState, _ := state.(State)
+		agentState.condition = true
+		return agentState, nil
+	})
+	graph.AddNode("node2", func(_ context.Context, state interface{}) (interface{}, error) {
+		agentState, _ := state.(State)
+		agentState.visited = "node2"
+		return agentState, nil
+	})
+	graph.AddNode("node3", func(_ context.Context, state interface{}) (interface{}, error) {
+		agentState, _ := state.(State)
+		agentState.visited = "node3"
+		return agentState, nil
+	})
+	graph.AddNode(END, func(_ context.Context, state interface{}) (interface{}, error) {
+		return state, nil
+	})
+	graph.AddConditionalEdge("node1", "node2", "node3", func(_ context.Context, state interface{}) (bool, error) {
+		agentState, ok := state.(State)
+		condition := agentState.condition
+		if !ok {
+			return false, nil
+		}
+		return condition, nil
+	})
+	graph.AddEdge("node2", g.END)
+	graph.AddEdge("node3", g.END)
 
-			if tc.expectedError != nil {
-				t.Fatalf("expected error %v, but got nil", tc.expectedError)
-			}
+	graph.SetEntryPoint("node1")
+	runnable, err := graph.Compile()
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
 
-			if len(output) != len(tc.expectedOutput) {
-				t.Fatalf("expected output length %d, but got %d", len(tc.expectedOutput), len(output))
-			}
-
-			for i, msg := range output {
-				got := fmt.Sprint(msg)
-				expected := fmt.Sprint(tc.expectedOutput[i])
-				if got != expected {
-					t.Errorf("expected output[%d] content %q, but got %q", i, expected, got)
-				}
-			}
-		})
+	result, err := runnable.Invoke(context.Background(), state)
+	agentResult, _ := result.(State)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if agentResult.visited != "node2" {
+		t.Errorf("Expected 'visited' to be 'node2', got '%v'", agentResult.visited)
 	}
 }


### PR DESCRIPTION
**What is this PR:**
- Add the feature of "AddCondionalEdge" for the graph
- Replace Node call back function to receive any type State. (Follow langgraph low-level framework design, the state should be defined by customer, but not combined any llms struct)

**Why I submit this PR:**
We folk the langgrpahGo code in our project, and find some limitation for original code. So we add some feature and fix defined based on Langgraph Python version principle.